### PR TITLE
Updates to get ev3-kernel to compile with 6.12.60

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "drivers/lego"]
 	path = drivers/lego
-	url = https://github.com/ev3dev/lego-linux-drivers
+	url = https://github.com/project516/lego-linux-drivers

--- a/arch/arm/mach-davinci/legoev3-fiq.c
+++ b/arch/arm/mach-davinci/legoev3-fiq.c
@@ -866,7 +866,7 @@ static int legoev3_fiq_probe(struct platform_device *pdev)
 
 	ret = gpio_request(pdata->status_gpio, "fiq status");
 	if (!ret) {
-    	ret = gpio_direction_output(pdata->status_gpio, 0);
+		ret = gpio_direction_output(pdata->status_gpio, 0);
 	}
 	
 	if (ret < 0) {

--- a/arch/arm/mach-davinci/legoev3-fiq.c
+++ b/arch/arm/mach-davinci/legoev3-fiq.c
@@ -868,7 +868,6 @@ static int legoev3_fiq_probe(struct platform_device *pdev)
 	if (!ret) {
 		ret = gpio_direction_output(pdata->status_gpio, 0);
 	}
-	
 	if (ret < 0) {
 		if (ret != -EPROBE_DEFER) {
 			dev_err(&pdev->dev,

--- a/arch/arm/mach-davinci/legoev3-fiq.c
+++ b/arch/arm/mach-davinci/legoev3-fiq.c
@@ -864,7 +864,11 @@ static int legoev3_fiq_probe(struct platform_device *pdev)
 	fiq_data->timer_irq = pdata->timer_irq;
 	fiq_data->ehrpwm_irq = pdata->ehrpwm_irq;
 
-	ret = gpio_request_one(pdata->status_gpio, GPIOF_INIT_LOW, "fiq status");
+	ret = gpio_request(pdata->status_gpio, "fiq status");
+	if (!ret) {
+    	ret = gpio_direction_output(pdata->status_gpio, 0);
+	}
+	
 	if (ret < 0) {
 		if (ret != -EPROBE_DEFER) {
 			dev_err(&pdev->dev,

--- a/scripts/Makefile.package
+++ b/scripts/Makefile.package
@@ -123,7 +123,7 @@ bindeb-pkg: private build-type := binary
 deb-pkg srcdeb-pkg: debian-orig
 bindeb-pkg: debian
 deb-pkg srcdeb-pkg bindeb-pkg:
-	+$(strip dpkg-buildpackage \
+	+$(strip dpkg-buildpackage -d \
 	--build=$(build-type) --no-pre-clean --unsigned-changes \
 	$(if $(findstring source, $(build-type)), \
 		--unsigned-source --compression=$(KDEB_SOURCE_COMPRESS)) \


### PR DESCRIPTION
This pull request includes several updates related to submodule management, GPIO initialization, and packaging scripts. The most significant changes are grouped below:

**Submodule and Dependency Updates:**

* Updated the URL for the `drivers/lego` submodule in `.gitmodules` to point to `project516/lego-linux-drivers` instead of the previous `ev3dev` repository.
* Updated the `drivers/lego` submodule to a new commit (`bec2d381...`) to reflect the latest changes from the new upstream.

**Platform Device Initialization:**

* Changed GPIO initialization in `legoev3_fiq_probe` (`arch/arm/mach-davinci/legoev3-fiq.c`) to use `gpio_request` followed by an explicit call to `gpio_direction_output`, improving clarity and compatibility.

**Build and Packaging:**

* Modified the `bindeb-pkg` build rule in `scripts/Makefile.package` to pass the `-d` flag to `dpkg-buildpackage`, which disables checking of build dependencies, potentially streamlining package builds in certain environments.